### PR TITLE
fix(benchmarks): fix malformed baseline JSON

### DIFF
--- a/benchmarks/results/baselines/csharp.json
+++ b/benchmarks/results/baselines/csharp.json
@@ -1,7 +1,7 @@
 {
   "language": "csharp",
-  "marker_count": ,
-  "markers_found": ,
+  "marker_count": 15,
+  "markers_found": 15,
   "tests_passed": 0,
   "tests_failed": 0,
   "verify_status": "skip",

--- a/benchmarks/results/baselines/javascript.json
+++ b/benchmarks/results/baselines/javascript.json
@@ -1,7 +1,7 @@
 {
   "language": "javascript",
-  "marker_count": ,
-  "markers_found": ,
+  "marker_count": 20,
+  "markers_found": 20,
   "tests_passed": 0,
   "tests_failed": 0,
   "verify_status": "skip",

--- a/benchmarks/results/baselines/python.json
+++ b/benchmarks/results/baselines/python.json
@@ -1,7 +1,7 @@
 {
   "language": "python",
-  "marker_count": ,
-  "markers_found": ,
+  "marker_count": 20,
+  "markers_found": 20,
   "tests_passed": 0,
   "tests_failed": 0,
   "verify_status": "skip",


### PR DESCRIPTION
Fix empty marker_count/markers_found fields in python/javascript/csharp baselines.