### PR TITLE
feat: generate RTMX results from pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ rtmx backlog
 
 # Run health check
 rtmx health
+
+# Generate RTMX results JSON from pytest markers and JUnit XML
+rtmx from-pytest tests/ --output .rtmx/cache/pytest-results.json
+rtmx verify --results .rtmx/cache/pytest-results.json --update
 ```
 
 ## Migrating from Python CLI

--- a/docs/LIFECYCLE.md
+++ b/docs/LIFECYCLE.md
@@ -626,6 +626,7 @@ rtmx diff BASELINE [CURRENT]             Compare RTM versions (for PRs)
 
 ```
 rtmx from-tests [--update]               Sync from pytest markers
+rtmx from-pytest [--output results.json] Generate RTMX results from pytest
 rtmx bootstrap [--from-tests] [--merge]  Generate from artifacts
 rtmx install [--all] [--dry-run]         Install agent prompts
 rtmx sync {github|jira} [--import]       Sync with external services

--- a/internal/cmd/from_pytest.go
+++ b/internal/cmd/from_pytest.go
@@ -1,0 +1,229 @@
+package cmd
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/rtmx-ai/rtmx/internal/results"
+	"github.com/spf13/cobra"
+)
+
+var (
+	fromPytestCommand string
+	fromPytestJUnit   string
+	fromPytestOutput  string
+	fromPytestNoRun   bool
+)
+
+var fromPytestCmd = &cobra.Command{
+	Use:   "from-pytest [test_path]",
+	Short: "Generate RTMX results JSON from pytest markers and JUnit XML",
+	Long: `Generate RTMX results JSON from pytest tests marked with
+@pytest.mark.req("REQ-...").
+
+By default this command runs pytest with a temporary --junitxml file, scans the
+test tree for RTMX requirement markers, joins pytest results back to those
+markers, and writes language-agnostic RTMX results JSON. The output can then be
+used directly with:
+
+  rtmx verify --results .rtmx/cache/pytest-results.json --update
+
+Use --junitxml with --no-run to convert an existing pytest JUnit XML file.`,
+	RunE: runFromPytest,
+}
+
+func init() {
+	fromPytestCmd.Flags().StringVar(&fromPytestCommand, "command", "pytest", "pytest command to run")
+	fromPytestCmd.Flags().StringVar(&fromPytestJUnit, "junitxml", "", "existing or generated pytest JUnit XML path")
+	fromPytestCmd.Flags().StringVarP(&fromPytestOutput, "output", "o", ".rtmx/cache/pytest-results.json", "RTMX results JSON output path")
+	fromPytestCmd.Flags().BoolVar(&fromPytestNoRun, "no-run", false, "do not run pytest; read --junitxml instead")
+
+	rootCmd.AddCommand(fromPytestCmd)
+}
+
+type junitTestSuites struct {
+	TestCases []junitTestCase  `xml:"testcase"`
+	Suites    []junitTestSuite `xml:"testsuite"`
+}
+
+type junitTestSuite struct {
+	TestCases []junitTestCase  `xml:"testcase"`
+	Suites    []junitTestSuite `xml:"testsuite"`
+}
+
+type junitTestCase struct {
+	ClassName string        `xml:"classname,attr"`
+	Name      string        `xml:"name,attr"`
+	File      string        `xml:"file,attr"`
+	Line      int           `xml:"line,attr"`
+	Time      float64       `xml:"time,attr"`
+	Failures  []interface{} `xml:"failure"`
+	Errors    []interface{} `xml:"error"`
+	Skipped   []interface{} `xml:"skipped"`
+}
+
+func runFromPytest(cmd *cobra.Command, args []string) error {
+	testPath := "tests"
+	if len(args) > 0 {
+		testPath = args[0]
+	}
+
+	markers, err := scanPytestMarkers(testPath)
+	if err != nil {
+		return err
+	}
+	if len(markers) == 0 {
+		return fmt.Errorf("no pytest requirement markers found under %s", testPath)
+	}
+
+	junitPath := fromPytestJUnit
+	cleanup := func() {}
+	if junitPath == "" {
+		tmp, err := os.CreateTemp("", "rtmx-pytest-*.xml")
+		if err != nil {
+			return fmt.Errorf("failed to create temporary JUnit file: %w", err)
+		}
+		junitPath = tmp.Name()
+		_ = tmp.Close()
+		cleanup = func() { _ = os.Remove(junitPath) }
+	}
+	defer cleanup()
+
+	if !fromPytestNoRun {
+		if err := runPytestForJUnit(testPath, junitPath); err != nil {
+			cmd.Printf("! pytest exited with error: %v\n", err)
+		}
+	}
+
+	cases, err := parsePytestJUnit(junitPath)
+	if err != nil {
+		return err
+	}
+
+	rtmxResults := buildPytestRTMXResults(markers, cases)
+	if len(rtmxResults) == 0 {
+		return fmt.Errorf("no pytest results matched RTMX requirement markers")
+	}
+
+	if err := writeRTMXResults(fromPytestOutput, rtmxResults); err != nil {
+		return err
+	}
+
+	cmd.Printf("Wrote %d RTMX pytest result(s) to %s\n", len(rtmxResults), fromPytestOutput)
+	return nil
+}
+
+func scanPytestMarkers(testPath string) ([]TestRequirement, error) {
+	info, err := os.Stat(testPath)
+	if err != nil {
+		return nil, fmt.Errorf("test path does not exist: %s", testPath)
+	}
+	if info.IsDir() {
+		return scanTestDirectory(testPath)
+	}
+	return extractMarkersFromSingleFile(testPath)
+}
+
+func runPytestForJUnit(testPath, junitPath string) error {
+	parts := strings.Fields(fromPytestCommand)
+	if len(parts) == 0 {
+		return fmt.Errorf("empty pytest command")
+	}
+	args := append([]string{}, parts[1:]...)
+	args = append(args, testPath, "--junitxml", junitPath)
+	cmd := exec.Command(parts[0], args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Dir, _ = os.Getwd()
+	return cmd.Run()
+}
+
+func parsePytestJUnit(path string) ([]junitTestCase, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read pytest JUnit XML: %w", err)
+	}
+
+	var suites junitTestSuites
+	if err := xml.Unmarshal(data, &suites); err != nil {
+		var suite junitTestSuite
+		if err2 := xml.Unmarshal(data, &suite); err2 != nil {
+			return nil, fmt.Errorf("failed to parse pytest JUnit XML: %w", err)
+		}
+		return flattenJUnitSuite(suite), nil
+	}
+
+	var cases []junitTestCase
+	cases = append(cases, suites.TestCases...)
+	for _, suite := range suites.Suites {
+		cases = append(cases, flattenJUnitSuite(suite)...)
+	}
+	return cases, nil
+}
+
+func flattenJUnitSuite(suite junitTestSuite) []junitTestCase {
+	cases := append([]junitTestCase{}, suite.TestCases...)
+	for _, nested := range suite.Suites {
+		cases = append(cases, flattenJUnitSuite(nested)...)
+	}
+	return cases
+}
+
+func buildPytestRTMXResults(markers []TestRequirement, cases []junitTestCase) []results.Result {
+	caseIndex := make(map[string]junitTestCase)
+	for _, tc := range cases {
+		for _, key := range pytestCaseKeys(tc) {
+			caseIndex[key] = tc
+		}
+	}
+
+	var out []results.Result
+	for _, marker := range markers {
+		tc, ok := caseIndex[marker.TestFunction]
+		if !ok {
+			continue
+		}
+		out = append(out, results.Result{
+			Marker: results.Marker{
+				ReqID:    marker.ReqID,
+				TestName: marker.TestFunction,
+				TestFile: filepath.ToSlash(marker.TestFile),
+				Line:     marker.LineNumber,
+			},
+			Passed:   len(tc.Failures) == 0 && len(tc.Errors) == 0 && len(tc.Skipped) == 0,
+			Duration: tc.Time * 1000,
+		})
+	}
+	return out
+}
+
+func pytestCaseKeys(tc junitTestCase) []string {
+	keys := []string{tc.Name}
+	if tc.ClassName != "" {
+		parts := strings.Split(tc.ClassName, ".")
+		className := parts[len(parts)-1]
+		if className != "" {
+			keys = append(keys, className+"::"+tc.Name)
+		}
+	}
+	return keys
+}
+
+func writeRTMXResults(path string, rtmxResults []results.Result) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("failed to create results directory: %w", err)
+	}
+	data, err := json.MarshalIndent(rtmxResults, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode RTMX results: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+		return fmt.Errorf("failed to write RTMX results: %w", err)
+	}
+	return nil
+}

--- a/internal/cmd/from_pytest_test.go
+++ b/internal/cmd/from_pytest_test.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rtmx-ai/rtmx/internal/results"
+	"github.com/rtmx-ai/rtmx/pkg/rtmx"
+)
+
+func TestBuildPytestRTMXResults(t *testing.T) {
+	rtmx.Req(t, "REQ-LANG-004")
+
+	markers := []TestRequirement{
+		{
+			ReqID:        "REQ-PY-001",
+			TestFile:     "tests/test_auth.py",
+			TestFunction: "TestAuth::test_login",
+			LineNumber:   12,
+		},
+		{
+			ReqID:        "REQ-PY-002",
+			TestFile:     "tests/test_auth.py",
+			TestFunction: "test_logout",
+			LineNumber:   20,
+		},
+	}
+	cases := []junitTestCase{
+		{ClassName: "tests.test_auth.TestAuth", Name: "test_login", Time: 0.25},
+		{ClassName: "tests.test_auth", Name: "test_logout", Failures: []interface{}{struct{}{}}},
+	}
+
+	got := buildPytestRTMXResults(markers, cases)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 RTMX results, got %d", len(got))
+	}
+	if got[0].Marker.ReqID != "REQ-PY-001" || !got[0].Passed {
+		t.Fatalf("expected passing REQ-PY-001 result, got %#v", got[0])
+	}
+	if got[1].Marker.ReqID != "REQ-PY-002" || got[1].Passed {
+		t.Fatalf("expected failing REQ-PY-002 result, got %#v", got[1])
+	}
+	if got[0].Duration != 250 {
+		t.Fatalf("expected duration in ms, got %v", got[0].Duration)
+	}
+}
+
+func TestParsePytestJUnit(t *testing.T) {
+	rtmx.Req(t, "REQ-LANG-004")
+
+	tmpDir := t.TempDir()
+	junitPath := filepath.Join(tmpDir, "pytest.xml")
+	xml := `<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest">
+    <testcase classname="tests.test_auth.TestAuth" name="test_login" time="0.1"></testcase>
+    <testcase classname="tests.test_auth" name="test_logout" time="0.2"><failure>boom</failure></testcase>
+  </testsuite>
+</testsuites>`
+	if err := os.WriteFile(junitPath, []byte(xml), 0644); err != nil {
+		t.Fatalf("failed to write junit fixture: %v", err)
+	}
+
+	cases, err := parsePytestJUnit(junitPath)
+	if err != nil {
+		t.Fatalf("parsePytestJUnit failed: %v", err)
+	}
+	if len(cases) != 2 {
+		t.Fatalf("expected 2 cases, got %d", len(cases))
+	}
+	if cases[1].Name != "test_logout" || len(cases[1].Failures) != 1 {
+		t.Fatalf("expected failed logout case, got %#v", cases[1])
+	}
+}
+
+func TestFromPytestNoRunWritesResults(t *testing.T) {
+	rtmx.Req(t, "REQ-LANG-004")
+
+	tmpDir := t.TempDir()
+	testsDir := filepath.Join(tmpDir, "tests")
+	if err := os.MkdirAll(testsDir, 0755); err != nil {
+		t.Fatalf("failed to create tests dir: %v", err)
+	}
+
+	testFile := filepath.Join(testsDir, "test_auth.py")
+	testContent := `import pytest
+
+class TestAuth:
+    @pytest.mark.req("REQ-PY-001")
+    def test_login(self):
+        pass
+`
+	if err := os.WriteFile(testFile, []byte(testContent), 0644); err != nil {
+		t.Fatalf("failed to write pytest fixture: %v", err)
+	}
+
+	junitPath := filepath.Join(tmpDir, "pytest.xml")
+	junit := `<?xml version="1.0" encoding="utf-8"?>
+<testsuite name="pytest">
+  <testcase classname="tests.test_auth.TestAuth" name="test_login" time="0.1"></testcase>
+</testsuite>`
+	if err := os.WriteFile(junitPath, []byte(junit), 0644); err != nil {
+		t.Fatalf("failed to write junit fixture: %v", err)
+	}
+
+	outputPath := filepath.Join(tmpDir, "results.json")
+	origCommand, origJUnit, origOutput, origNoRun := fromPytestCommand, fromPytestJUnit, fromPytestOutput, fromPytestNoRun
+	fromPytestCommand = "pytest"
+	fromPytestJUnit = junitPath
+	fromPytestOutput = outputPath
+	fromPytestNoRun = true
+	defer func() {
+		fromPytestCommand, fromPytestJUnit, fromPytestOutput, fromPytestNoRun = origCommand, origJUnit, origOutput, origNoRun
+	}()
+
+	cmd := newTestRootCmd()
+	if err := runFromPytest(cmd, []string{testsDir}); err != nil {
+		t.Fatalf("runFromPytest failed: %v", err)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+	var parsed []results.Result
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid RTMX results JSON: %v", err)
+	}
+	if len(parsed) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(parsed))
+	}
+	if parsed[0].Marker.ReqID != "REQ-PY-001" || !parsed[0].Passed {
+		t.Fatalf("unexpected result: %s", strings.TrimSpace(string(data)))
+	}
+}

--- a/test/release_test.go
+++ b/test/release_test.go
@@ -77,6 +77,7 @@ func TestV010Release(t *testing.T) {
 			"init",
 			"verify",
 			"from-tests",
+			"from-pytest",
 			"deps",
 			"cycles",
 		}
@@ -230,6 +231,7 @@ func TestV1Release(t *testing.T) {
 			"verify",
 			"from-go",
 			"from-tests",
+			"from-pytest",
 			"reconcile",
 			"context",
 			"install",


### PR DESCRIPTION
## Summary
- Add `rtmx from-pytest` to generate RTMX results JSON from pytest markers and JUnit XML.
- Support both running pytest directly and converting an existing `--junitxml` file.
- Document the pytest closed-loop flow: `from-pytest` followed by `verify --results`.

## Test plan
- `go test ./internal/cmd ./internal/results`
- `go test ./...`

Made with [Cursor](https://cursor.com)