### PR TITLE
fix(from-pytest): carry marker dimensions and omit skipped tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to RTMX are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.7.0]
+
+### Fixed
+
+- **`rtmx from-pytest` now carries marker dimensions and omits skipped tests.**
+  The JUnit-based pytest path emitted dimensionless results and recorded
+  `skipif`/`xfail` tests as failures. It now maps each test's
+  `scope_*`/`technique_*`/`env_*` pytest markers into the results schema's
+  `scope`/`technique`/`env` fields (e.g. `scope_unit` → `unit`,
+  `env_static_field` → `static_field`), so projects using a multi-dimensional
+  completeness policy can reach COMPLETE from the pytest path; and it omits
+  skipped tests entirely so a hardware-gated `skipif` no longer downgrades a
+  requirement. (REQ-LANG-004)
+
 ## [1.4.0] - 2026-06-04
 
 ### Added

--- a/internal/cmd/from_pytest.go
+++ b/internal/cmd/from_pytest.go
@@ -188,18 +188,47 @@ func buildPytestRTMXResults(markers []TestRequirement, cases []junitTestCase) []
 		if !ok {
 			continue
 		}
+		// A skipped (or xfail, which pytest reports as skipped in JUnit) test is
+		// not evidence: it must neither promote nor downgrade a requirement, so
+		// omit it entirely rather than recording it as a failure.
+		if len(tc.Skipped) > 0 {
+			continue
+		}
+		scope, technique, env := pytestMarkerDimensions(marker.Markers)
 		out = append(out, results.Result{
 			Marker: results.Marker{
-				ReqID:    marker.ReqID,
-				TestName: marker.TestFunction,
-				TestFile: filepath.ToSlash(marker.TestFile),
-				Line:     marker.LineNumber,
+				ReqID:     marker.ReqID,
+				Scope:     scope,
+				Technique: technique,
+				Env:       env,
+				TestName:  marker.TestFunction,
+				TestFile:  filepath.ToSlash(marker.TestFile),
+				Line:      marker.LineNumber,
 			},
-			Passed:   len(tc.Failures) == 0 && len(tc.Errors) == 0 && len(tc.Skipped) == 0,
+			Passed:   len(tc.Failures) == 0 && len(tc.Errors) == 0,
 			Duration: tc.Time * 1000,
 		})
 	}
 	return out
+}
+
+// pytestMarkerDimensions maps the scope_*/technique_*/env_* pytest markers
+// collected for a test into the results schema's scope/technique/env dimensions
+// (e.g. "scope_unit" -> "unit", "env_static_field" -> "static_field"). Without
+// this, the JUnit-based pytest path produced dimensionless results, so projects
+// using a multi-dimensional completeness policy could never reach COMPLETE.
+func pytestMarkerDimensions(markers []string) (scope, technique, env string) {
+	for _, m := range markers {
+		switch {
+		case strings.HasPrefix(m, "scope_"):
+			scope = strings.TrimPrefix(m, "scope_")
+		case strings.HasPrefix(m, "technique_"):
+			technique = strings.TrimPrefix(m, "technique_")
+		case strings.HasPrefix(m, "env_"):
+			env = strings.TrimPrefix(m, "env_")
+		}
+	}
+	return scope, technique, env
 }
 
 func pytestCaseKeys(tc junitTestCase) []string {

--- a/internal/cmd/from_pytest_test.go
+++ b/internal/cmd/from_pytest_test.go
@@ -48,6 +48,45 @@ func TestBuildPytestRTMXResults(t *testing.T) {
 	}
 }
 
+func TestBuildPytestRTMXResultsDimensionsAndSkip(t *testing.T) {
+	rtmx.Req(t, "REQ-LANG-004",
+		rtmx.Scope("unit"), rtmx.Technique("nominal"), rtmx.Env("simulation"))
+
+	markers := []TestRequirement{
+		{ReqID: "REQ-PY-010", TestFile: "tests/test_x.py", TestFunction: "test_a", LineNumber: 5,
+			Markers: []string{"scope_unit", "technique_nominal", "env_simulation"}},
+		{ReqID: "REQ-PY-011", TestFile: "tests/test_x.py", TestFunction: "test_b", LineNumber: 9,
+			Markers: []string{"scope_integration", "technique_monte_carlo", "env_static_field"}},
+		{ReqID: "REQ-PY-012", TestFile: "tests/test_x.py", TestFunction: "test_skipped", LineNumber: 14,
+			Markers: []string{"scope_unit", "technique_nominal", "env_simulation"}},
+	}
+	cases := []junitTestCase{
+		{ClassName: "tests.test_x", Name: "test_a", Time: 0.1},
+		{ClassName: "tests.test_x", Name: "test_b", Time: 0.2},
+		{ClassName: "tests.test_x", Name: "test_skipped", Skipped: []interface{}{struct{}{}}},
+	}
+
+	got := buildPytestRTMXResults(markers, cases)
+
+	// The skipped test is omitted entirely (neither pass nor fail).
+	if len(got) != 2 {
+		t.Fatalf("expected 2 results (skipped omitted), got %d: %#v", len(got), got)
+	}
+	byReq := map[string]results.Marker{}
+	for _, r := range got {
+		byReq[r.Marker.ReqID] = r.Marker
+	}
+	if _, ok := byReq["REQ-PY-012"]; ok {
+		t.Error("skipped test must be omitted from results")
+	}
+	if m := byReq["REQ-PY-010"]; m.Scope != "unit" || m.Technique != "nominal" || m.Env != "simulation" {
+		t.Errorf("dimensions not mapped for REQ-PY-010: %#v", m)
+	}
+	if m := byReq["REQ-PY-011"]; m.Scope != "integration" || m.Technique != "monte_carlo" || m.Env != "static_field" {
+		t.Errorf("dimensions not mapped for REQ-PY-011: %#v", m)
+	}
+}
+
 func TestParsePytestJUnit(t *testing.T) {
 	rtmx.Req(t, "REQ-LANG-004")
 


### PR DESCRIPTION
## Problem

The JUnit-based `rtmx from-pytest` path has two fidelity gaps that make it unusable for projects with a multi-dimensional completeness policy (`rtmx.completeness.policy: combinations`):

1. **Dimensionless results.** `buildPytestRTMXResults` set only `req_id/test_name/test_file/line` on each result's marker, dropping `scope`/`technique`/`env`. So a `combinations` project (e.g. the Phoenix radar RTM with `dimensions: [scope, technique], min_combinations: 3`) could never reach COMPLETE from the pytest path — every requirement capped at PARTIAL. The marker scanner *already* collects the `scope_*`/`technique_*`/`env_*` markers into `TestRequirement.Markers`; they were simply never propagated.
2. **Skipped tests counted as failures.** `Passed` was `len(Failures)==0 && len(Errors)==0 && len(Skipped)==0`. pytest reports `skipif` and `xfail` as JUnit `<skipped>`, so a correctly-skipped hardware-gated test (e.g. `skipif(not PCBNEW_AVAILABLE)`) would **downgrade** its requirement on `verify --update`.

## Change

- Map the already-collected `scope_*`/`technique_*`/`env_*` markers into the results schema's `scope`/`technique`/`env` (e.g. `scope_unit` → `unit`, `env_static_field` → `static_field`).
- Omit skipped cases entirely — a skipped test is not evidence and must neither promote nor downgrade a requirement.

## Result

Verified end-to-end against a real `combinations`-policy project: results now carry dimensions, requirements with ≥3 distinct `scope×technique` combos promote MISSING → COMPLETE from the pytest path, and `skipif` tests no longer pull requirements down.

## Tests

`internal/cmd/from_pytest_test.go::TestBuildPytestRTMXResultsDimensionsAndSkip` covers dimension mapping and skip omission. `go test ./...`, `go vet`, `gofmt`, `make lint` (0 issues) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)