### PR TITLE
feat(from-pytest): accept multiple test paths + path-qualified JUnit join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to RTMX are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.8.0]
+
+### Added
+
+- **`rtmx from-pytest` accepts multiple test paths.** Previously it scanned and
+  ran only a single path (default `tests`), so a multi-package layout — a
+  top-level `tests/` plus `packages/*/tests/` — could not be reconciled in one
+  invocation (the other packages were silently never scored). It now accepts one
+  or more paths (`rtmx from-pytest tests packages/foo/tests packages/bar/tests`)
+  and scans + runs all of them.
+
+### Fixed
+
+- **Path-qualified JUnit join.** Test results are now matched to scanned markers
+  by repo-relative file path first, falling back to the bare function name. This
+  prevents a passing test in one file from being mis-attributed to a same-named
+  test in another file — a real hazard once a multi-package tree is scanned.
+
 ## [1.7.0]
 
 ### Fixed

--- a/internal/cmd/from_pytest.go
+++ b/internal/cmd/from_pytest.go
@@ -21,7 +21,7 @@ var (
 )
 
 var fromPytestCmd = &cobra.Command{
-	Use:   "from-pytest [test_path]",
+	Use:   "from-pytest [test_path...]",
 	Short: "Generate RTMX results JSON from pytest markers and JUnit XML",
 	Long: `Generate RTMX results JSON from pytest tests marked with
 @pytest.mark.req("REQ-...").
@@ -68,17 +68,24 @@ type junitTestCase struct {
 }
 
 func runFromPytest(cmd *cobra.Command, args []string) error {
-	testPath := "tests"
+	// Accept one or more test paths so multi-package layouts (e.g. a top-level
+	// tests/ plus packages/*/tests/) are scanned and run together; default to
+	// "tests" when none are given.
+	testPaths := []string{"tests"}
 	if len(args) > 0 {
-		testPath = args[0]
+		testPaths = args
 	}
 
-	markers, err := scanPytestMarkers(testPath)
-	if err != nil {
-		return err
+	var markers []TestRequirement
+	for _, p := range testPaths {
+		m, err := scanPytestMarkers(p)
+		if err != nil {
+			return err
+		}
+		markers = append(markers, m...)
 	}
 	if len(markers) == 0 {
-		return fmt.Errorf("no pytest requirement markers found under %s", testPath)
+		return fmt.Errorf("no pytest requirement markers found under %s", strings.Join(testPaths, ", "))
 	}
 
 	junitPath := fromPytestJUnit
@@ -95,7 +102,7 @@ func runFromPytest(cmd *cobra.Command, args []string) error {
 	defer cleanup()
 
 	if !fromPytestNoRun {
-		if err := runPytestForJUnit(testPath, junitPath); err != nil {
+		if err := runPytestForJUnit(testPaths, junitPath); err != nil {
 			cmd.Printf("! pytest exited with error: %v\n", err)
 		}
 	}
@@ -129,13 +136,14 @@ func scanPytestMarkers(testPath string) ([]TestRequirement, error) {
 	return extractMarkersFromSingleFile(testPath)
 }
 
-func runPytestForJUnit(testPath, junitPath string) error {
+func runPytestForJUnit(testPaths []string, junitPath string) error {
 	parts := strings.Fields(fromPytestCommand)
 	if len(parts) == 0 {
 		return fmt.Errorf("empty pytest command")
 	}
 	args := append([]string{}, parts[1:]...)
-	args = append(args, testPath, "--junitxml", junitPath)
+	args = append(args, testPaths...)
+	args = append(args, "--junitxml", junitPath)
 	cmd := exec.Command(parts[0], args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -184,7 +192,14 @@ func buildPytestRTMXResults(markers []TestRequirement, cases []junitTestCase) []
 
 	var out []results.Result
 	for _, marker := range markers {
-		tc, ok := caseIndex[marker.TestFunction]
+		var tc junitTestCase
+		ok := false
+		for _, k := range markerJoinKeys(marker) {
+			if c, found := caseIndex[k]; found {
+				tc, ok = c, true
+				break
+			}
+		}
 		if !ok {
 			continue
 		}
@@ -233,13 +248,45 @@ func pytestMarkerDimensions(markers []string) (scope, technique, env string) {
 
 func pytestCaseKeys(tc junitTestCase) []string {
 	keys := []string{tc.Name}
+	var className string
 	if tc.ClassName != "" {
 		parts := strings.Split(tc.ClassName, ".")
-		className := parts[len(parts)-1]
+		className = parts[len(parts)-1]
 		if className != "" {
 			keys = append(keys, className+"::"+tc.Name)
 		}
 	}
+	// Path-qualified keys disambiguate tests that share a function name across
+	// files (common once a multi-package tree is scanned), preventing a passing
+	// test in one file from joining a same-named test in another. The JUnit
+	// `file` attribute and the scanner's TestFile are both repo-relative paths.
+	if p := pyPathKey(tc.File); p != "" {
+		keys = append(keys, p+"::"+tc.Name)
+		if className != "" {
+			keys = append(keys, p+"::"+className+"::"+tc.Name)
+		}
+	}
+	return keys
+}
+
+// pyPathKey normalizes a test file path (slash-separated, cleaned) for use in
+// join keys so the JUnit `file` attribute and the scanner's TestFile agree.
+func pyPathKey(path string) string {
+	if path == "" {
+		return ""
+	}
+	return filepath.ToSlash(filepath.Clean(path))
+}
+
+// markerJoinKeys returns the candidate caseIndex keys for a scanned marker,
+// most-specific (path-qualified) first, so a join prefers an exact file match
+// and only falls back to the bare function name when JUnit carries no file.
+func markerJoinKeys(m TestRequirement) []string {
+	keys := []string{}
+	if p := pyPathKey(m.TestFile); p != "" {
+		keys = append(keys, p+"::"+m.TestFunction)
+	}
+	keys = append(keys, m.TestFunction)
 	return keys
 }
 

--- a/internal/cmd/from_pytest_test.go
+++ b/internal/cmd/from_pytest_test.go
@@ -87,6 +87,40 @@ func TestBuildPytestRTMXResultsDimensionsAndSkip(t *testing.T) {
 	}
 }
 
+func TestBuildPytestRTMXResultsFileQualifiedJoin(t *testing.T) {
+	rtmx.Req(t, "REQ-LANG-004",
+		rtmx.Scope("unit"), rtmx.Technique("stress"), rtmx.Env("simulation"))
+
+	// Two different files define a module-level test with the SAME function name.
+	// The passing one and the failing one must each join to their own file, not
+	// collide on the bare name.
+	markers := []TestRequirement{
+		{ReqID: "REQ-A-001", TestFile: "packages/foo/tests/test_dup.py", TestFunction: "test_thing", LineNumber: 3},
+		{ReqID: "REQ-B-001", TestFile: "tests/test_dup.py", TestFunction: "test_thing", LineNumber: 7},
+	}
+	cases := []junitTestCase{
+		{ClassName: "packages.foo.tests.test_dup", Name: "test_thing",
+			File: "packages/foo/tests/test_dup.py", Time: 0.1},
+		{ClassName: "tests.test_dup", Name: "test_thing",
+			File: "tests/test_dup.py", Failures: []interface{}{struct{}{}}},
+	}
+
+	got := buildPytestRTMXResults(markers, cases)
+	res := map[string]bool{}
+	for _, r := range got {
+		res[r.Marker.ReqID] = r.Passed
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 results, got %d: %#v", len(got), got)
+	}
+	if !res["REQ-A-001"] {
+		t.Error("REQ-A-001 (packages/foo) should join its PASSING case, not the failing same-named one")
+	}
+	if res["REQ-B-001"] {
+		t.Error("REQ-B-001 (tests/) should join its FAILING case, not the passing same-named one")
+	}
+}
+
 func TestParsePytestJUnit(t *testing.T) {
 	rtmx.Req(t, "REQ-LANG-004")
 


### PR DESCRIPTION
## Problem

`rtmx from-pytest` scanned and ran only a **single** test path (default `tests`). In a multi-package layout — a top-level `tests/` plus one or more `packages/*/tests/` — only the one path was reconciled; every requirement whose tests live in the other packages stayed MISSING even with passing tests. (Found while reconciling a radar project whose `packages/{common,radar-hal,signal-processing}/tests` were all silently skipped.)

A second, related hazard: results were joined to scanned markers by the bare function name, so once a broad tree is scanned, a passing `test_foo` in one file could be mis-attributed to a failing `test_foo` in another — corrupting status.

## Change

- **Multiple test paths.** `runFromPytest` now accepts variadic paths and scans + runs all of them: `rtmx from-pytest tests packages/foo/tests packages/bar/tests`. Defaults to `tests` when none are given (unchanged single-path behavior).
- **Path-qualified join.** `pytestCaseKeys`/`markerJoinKeys` add a repo-relative-path-qualified key (`<file>::<func>`, and `<file>::<Class>::<func>`), tried before the bare-name fallback, using the JUnit `file` attribute and the scanner's `TestFile`. A same-named test in a different file no longer collides.

## Tests

- `TestBuildPytestRTMXResultsFileQualifiedJoin`: two files define a same-named module-level test (one passing, one failing); each joins its own file.
- Existing pytest tests still pass (bare-name fallback preserved for JUnit without a `file` attr).
- `go test ./...` (21 pkgs), `go vet`, `gofmt`, `make lint` (0 issues) all green.
- Verified end-to-end against a multi-package project: requirements in `packages/*/tests` now score with full `scope/technique` dimensions (e.g. a 3-combo requirement reaches COMPLETE).

Builds on #125 (dimensions + skip omission).

🤖 Generated with [Claude Code](https://claude.com/claude-code)